### PR TITLE
Warn users on older versions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ prompt-toolkit==3.0.43
 # Setup
 pip==24.0
 # Code Quality
-pyright==1.1.365
+pyright==1.1.367
 ruff==0.4.1
 # Build/Release
 setuptools==69.5.1

--- a/python/tach.yml
+++ b/python/tach.yml
@@ -1,16 +1,10 @@
 modules:
 - path: tach
+  depends_on: []
+  strict: true
+- path: tach.__main__
   depends_on:
-  - tach.cache
-  - tach.check
-  - tach.colors
-  - tach.constants
-  - tach.core
-  - tach.errors
-  - tach.filesystem
-  - tach.interactive
-  - tach.logging
-  - tach.parsing
+  - tach.cli
   strict: true
 - path: tach.cache
   depends_on:
@@ -22,7 +16,26 @@ modules:
   - tach.errors
   - tach.filesystem
   - tach.parsing
-  strict: false
+  strict: true
+- path: tach.clean
+  depends_on:
+  - tach.filesystem
+  strict: true
+- path: tach.cli
+  depends_on:
+  - tach
+  - tach.cache
+  - tach.check
+  - tach.clean
+  - tach.colors
+  - tach.constants
+  - tach.core
+  - tach.filesystem
+  - tach.logging
+  - tach.mod
+  - tach.parsing
+  - tach.sync
+  strict: true
 - path: tach.colors
   depends_on: []
   strict: true
@@ -58,10 +71,29 @@ modules:
   - tach.cache
   - tach.parsing
   strict: true
+- path: tach.mod
+  depends_on:
+  - tach.colors
+  - tach.constants
+  - tach.core
+  - tach.errors
+  - tach.filesystem
+  - tach.interactive
+  - tach.parsing
+  strict: true
 - path: tach.parsing
   depends_on:
   - tach.core
   - tach.filesystem
+  strict: true
+- path: tach.sync
+  depends_on:
+  - tach.check
+  - tach.colors
+  - tach.constants
+  - tach.errors
+  - tach.filesystem
+  - tach.parsing
   strict: true
 exclude:
 - .*__pycache__/

--- a/python/tach.yml
+++ b/python/tach.yml
@@ -1,6 +1,7 @@
 modules:
 - path: tach
   depends_on:
+  - tach.cache
   - tach.check
   - tach.colors
   - tach.constants

--- a/python/tach.yml
+++ b/python/tach.yml
@@ -1,6 +1,7 @@
 modules:
 - path: tach
   depends_on:
+  - tach.check
   - tach.colors
   - tach.constants
   - tach.core
@@ -12,8 +13,15 @@ modules:
   strict: true
 - path: tach.cache
   depends_on:
+  - tach
   - tach.filesystem
   strict: true
+- path: tach.check
+  depends_on:
+  - tach.errors
+  - tach.filesystem
+  - tach.parsing
+  strict: false
 - path: tach.colors
   depends_on: []
   strict: true
@@ -45,6 +53,7 @@ modules:
   strict: true
 - path: tach.logging
   depends_on:
+  - tach
   - tach.cache
   - tach.parsing
   strict: true

--- a/python/tach/__init__.py
+++ b/python/tach/__init__.py
@@ -1,3 +1,5 @@
 from __future__ import annotations
 
 __version__ = "0.5.1"
+
+__all__ = ["__version__"]

--- a/python/tach/__init__.py
+++ b/python/tach/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
 
+__version__ = "0.5.1"

--- a/python/tach/cache/__init__.py
+++ b/python/tach/cache/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from tach.cache.access import get_uid
+from tach.cache.access import get_latest_version, get_uid, update_latest_version
 
-__all__ = ["get_uid"]
+__all__ = ["get_uid", "update_latest_version", "get_latest_version"]

--- a/python/tach/cache/access.py
+++ b/python/tach/cache/access.py
@@ -13,8 +13,8 @@ def get_uid() -> uuid.UUID | None:
         return
     if not (project_path / ".tach" / "tach.info").exists():
         resolve_dot_tach()
-    with open(project_path / ".tach" / "tach.info") as f:
-        uid = uuid.UUID(f.read().strip())
+    contents = (project_path / ".tach" / "tach.info").read_text().strip()
+    uid = uuid.UUID(contents)
     return uid
 
 
@@ -24,8 +24,7 @@ def get_latest_version() -> str | None:
         return
     if not (project_path / ".tach" / ".latest-version").exists():
         return
-    with open(project_path / ".tach" / ".latest-version") as f:
-        version = f.read().strip()
+    version = (project_path / ".tach" / "latest-version").read_text().strip()
     return version
 
 

--- a/python/tach/cache/access.py
+++ b/python/tach/cache/access.py
@@ -1,19 +1,36 @@
 from __future__ import annotations
 
 import uuid
-from pathlib import Path
 
-from tach.cache.setup import resolve_dot_tach
-from tach.filesystem import find_project_config_root
+from tach.cache.setup import get_project_path, resolve_dot_tach
 
 
 def get_uid() -> uuid.UUID | None:
-    project_root = find_project_config_root(str(Path.cwd()))
-    if project_root is None:
+    project_path = get_project_path()
+    if project_path is None:
         return
-    project_path = Path(project_root)
     if not (project_path / ".tach" / "tach.info").exists():
         resolve_dot_tach()
     with open(project_path / ".tach" / "tach.info") as f:
         uid = uuid.UUID(f.read().strip())
     return uid
+
+
+def get_latest_version() -> str | None:
+    project_path = get_project_path()
+    if project_path is None:
+        return
+    if not (project_path / ".tach" / ".latest-version").exists():
+        resolve_dot_tach()
+        update_latest_version()
+    with open(project_path / ".tach" / ".latest-version") as f:
+        version = f.read().strip()
+    return version
+
+
+def update_latest_version() -> None:
+    # TODO make api request to https://pypi.org/pypi/tach/json
+    project_path = get_project_path()
+    if project_path is None:
+        return
+    (project_path / ".tach" / ".latest-version").write_text("0.5.2")

--- a/python/tach/cache/access.py
+++ b/python/tach/cache/access.py
@@ -24,7 +24,7 @@ def get_latest_version() -> str | None:
         return
     if not (project_path / ".tach" / ".latest-version").exists():
         return
-    version = (project_path / ".tach" / "latest-version").read_text().strip()
+    version = (project_path / ".tach" / ".latest-version").read_text().strip()
     return version
 
 

--- a/python/tach/cache/access.py
+++ b/python/tach/cache/access.py
@@ -11,9 +11,10 @@ def get_uid() -> uuid.UUID | None:
     project_path = get_project_path()
     if project_path is None:
         return
-    if not (project_path / ".tach" / "tach.info").exists():
+    info_path = project_path / ".tach" / "tach.info"
+    if not info_path.exists():
         resolve_dot_tach()
-    contents = (project_path / ".tach" / "tach.info").read_text().strip()
+    contents = info_path.read_text().strip()
     uid = uuid.UUID(contents)
     return uid
 
@@ -22,9 +23,10 @@ def get_latest_version() -> str | None:
     project_path = get_project_path()
     if project_path is None:
         return
-    if not (project_path / ".tach" / ".latest-version").exists():
+    latest_version_path = project_path / ".tach" / ".latest-version"
+    if not latest_version_path.exists():
         return
-    version = (project_path / ".tach" / ".latest-version").read_text().strip()
+    version = latest_version_path.read_text().strip()
     return version
 
 

--- a/python/tach/cache/setup.py
+++ b/python/tach/cache/setup.py
@@ -3,14 +3,21 @@ from __future__ import annotations
 import uuid
 from pathlib import Path
 
+from tach import __version__
 from tach.filesystem import find_project_config_root
 
 
-def resolve_dot_tach() -> Path | None:
-    project_dir = find_project_config_root(str(Path.cwd()))
-    if project_dir is None:
+def get_project_path() -> Path | None:
+    project_root = find_project_config_root(str(Path.cwd()))
+    if project_root is None:
         return
-    project_path = Path(project_dir)
+    project_path = Path(project_root)
+    return project_path
+
+def resolve_dot_tach() -> Path | None:
+    project_path = get_project_path()
+    if project_path is None:
+        return
 
     def _create(path: Path, is_file: bool = False, file_content: str = "") -> None:
         if not path.exists():
@@ -34,4 +41,7 @@ def resolve_dot_tach() -> Path | None:
     """
     gitignore_path = tach_path / ".gitignore"
     _create(gitignore_path, is_file=True, file_content=gitignore_content)
+    # Create version
+    version_path = tach_path / ".latest-version"
+    _create(version_path, is_file=True, file_content=__version__)
     return Path(tach_path)

--- a/python/tach/cache/setup.py
+++ b/python/tach/cache/setup.py
@@ -14,6 +14,7 @@ def get_project_path() -> Path | None:
     project_path = Path(project_root)
     return project_path
 
+
 def resolve_dot_tach() -> Path | None:
     project_path = get_project_path()
     if project_path is None:

--- a/python/tach/check.py
+++ b/python/tach/check.py
@@ -176,3 +176,6 @@ def check(
         return boundary_errors
     finally:
         fs.chdir(cwd)
+
+
+__all__ = ["BoundaryError", "check"]

--- a/python/tach/clean.py
+++ b/python/tach/clean.py
@@ -11,3 +11,6 @@ def clean_project(root: str) -> None:
     project_config_path = fs.get_project_config_path(root)
     if project_config_path:
         fs.delete_file(project_config_path)
+
+
+__all__ = ["clean_project"]

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from tach import __version__
 from tach import filesystem as fs
 from tach.check import BoundaryError, check
 from tach.clean import clean_project
@@ -129,6 +130,8 @@ def build_parser() -> argparse.ArgumentParser:
         epilog="Make sure tach is run from the root of your Python project,"
         " and `tach.yml` is present",
     )
+    parser.add_argument("--version", action="version", version=f"tach {__version__}")
+
     subparsers = parser.add_subparsers(title="commands", dest="command")
     mod_parser = subparsers.add_parser(
         "mod",

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from tach import __version__
+from tach import __version__, cache
 from tach import filesystem as fs
 from tach.check import BoundaryError, check
 from tach.clean import clean_project
@@ -401,6 +401,12 @@ def tach_install(path: str, target: InstallTarget, project_root: str = "") -> No
 
 def main() -> None:
     args, parser = parse_arguments(sys.argv[1:])
+    latest_version = cache.get_latest_version()
+    if latest_version and latest_version != __version__:
+        print(
+            f"{BCOLORS.WARNING}WARNING: there is a new tach version available"
+            f" ({__version__} -> {latest_version}). Upgrade to remove this warning.{BCOLORS.ENDC}"
+        )
     exclude_paths = args.exclude.split(",") if getattr(args, "exclude", None) else None
     if args.command == "mod":
         tach_mod(depth=args.depth, exclude_paths=exclude_paths)

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -433,3 +433,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+
+__all__ = ["main"]

--- a/python/tach/logging/logger.py
+++ b/python/tach/logging/logger.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
-from tach import cache
+from tach import __version__, cache
 from tach.logging.api import log_record, log_uid
 from tach.parsing import parse_project_config
 
@@ -26,6 +26,7 @@ def send_log_entry(record: logging.LogRecord, entry: str) -> None:
     is_gauge = "IS_GAUGE" in os.environ
     data: LogDataModel | None = getattr(record, "data", None)
     uid = cache.get_uid()
+    version = __version__
     log_data: dict[str, Any] = {
         "user": str(uid) if uid else None,
         "message": entry,
@@ -33,10 +34,12 @@ def send_log_entry(record: logging.LogRecord, entry: str) -> None:
         "timestamp": record.created,
         "function": data.function if data else None,
         "parameters": data.parameters if data else None,
+        "version": version,
     }
     if uid is not None:
         log_uid(uid=uid, is_ci=is_ci, is_gauge=is_gauge)
     log_record(record_data=log_data)
+    cache.update_latest_version()
 
 
 def handle_log_entry(record: logging.LogRecord, entry: str) -> None:

--- a/python/tach/mod.py
+++ b/python/tach/mod.py
@@ -42,3 +42,6 @@ def mod_edit_interactive(
         return True, []
     else:
         return False, [f"{BCOLORS.OKCYAN}No changes saved.{BCOLORS.ENDC}"]
+
+
+__all__ = ["mod_edit_interactive"]

--- a/python/tach/sync.py
+++ b/python/tach/sync.py
@@ -98,3 +98,6 @@ def sync_project(prune: bool = False, exclude_paths: list[str] | None = None) ->
 
     finally:
         fs.chdir(original_cwd)
+
+
+__all__ = ["sync_project", "prune_dependency_constraints"]

--- a/python/tests/test_cache.py
+++ b/python/tests/test_cache.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib.error import URLError
+
+from tach.cache.access import get_latest_version, get_uid, update_latest_version
+from tach.cache.setup import get_project_path, resolve_dot_tach
+
+
+@patch("tach.cache.setup.find_project_config_root")
+def test_get_project_path(mock_find_project_config_root):
+    mock_find_project_config_root.return_value = "/fake/project"
+    result = get_project_path()
+    assert result == Path("/fake/project")
+
+
+@patch("tach.cache.setup.find_project_config_root")
+def test_get_project_path_no_root(mock_find_project_config_root):
+    mock_find_project_config_root.return_value = None
+    result = get_project_path()
+    assert result is None
+
+
+@patch("tach.cache.setup.get_project_path")
+def test_resolve_dot_tach(mock_get_project_path, tmp_path):
+    project_path = tmp_path / "project"
+    project_path.mkdir(parents=True, exist_ok=True)
+    mock_get_project_path.return_value = project_path
+    version = "1.0.0"
+
+    with patch("tach.cache.setup.__version__", version):
+        result = resolve_dot_tach()
+
+    tach_path = project_path / ".tach"
+    assert tach_path.exists()
+    assert (tach_path / "tach.info").exists()
+    assert (tach_path / "tach.info").read_text().strip() != ""
+    assert (tach_path / ".gitignore").exists()
+    assert (tach_path / ".latest-version").exists()
+    assert (tach_path / ".latest-version").read_text().strip() == version
+    assert result == tach_path
+
+
+@patch("tach.cache.access.get_project_path")
+@patch("tach.cache.access.resolve_dot_tach")
+def test_get_uid(mock_resolve_dot_tach, mock_get_project_path, tmp_path):
+    project_path = tmp_path / "project"
+    tach_info_path = project_path / ".tach" / "tach.info"
+    tach_info_path.parent.mkdir(parents=True, exist_ok=True)
+    uid = uuid.uuid4()
+    tach_info_path.write_text(str(uid))
+
+    mock_get_project_path.return_value = project_path
+
+    result = get_uid()
+    assert result == uid
+
+
+@patch("tach.cache.access.get_project_path")
+def test_get_uid_no_project_path(mock_get_project_path):
+    mock_get_project_path.return_value = None
+    result = get_uid()
+    assert result is None
+
+
+@patch("tach.cache.access.get_project_path")
+def test_get_latest_version(mock_get_project_path, tmp_path):
+    project_path = tmp_path / "project"
+    latest_version_path = project_path / ".tach" / ".latest-version"
+    latest_version_path.parent.mkdir(parents=True, exist_ok=True)
+    version = "1.0.0"
+    latest_version_path.write_text(version)
+
+    mock_get_project_path.return_value = project_path
+
+    result = get_latest_version()
+    assert result == version
+
+
+@patch("tach.cache.access.get_project_path")
+def test_update_latest_version(mock_get_project_path, tmp_path):
+    project_path = tmp_path / "project"
+    latest_version_path = project_path / ".tach" / ".latest-version"
+    latest_version_path.parent.mkdir(parents=True, exist_ok=True)
+
+    mock_get_project_path.return_value = project_path
+
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = json.dumps(
+        {"info": {"version": "1.0.1"}}
+    ).encode()
+    mock_urlopen = MagicMock()
+    mock_urlopen.return_value.__enter__.return_value = mock_response
+
+    with patch("tach.cache.access.request.urlopen", mock_urlopen):
+        update_latest_version()
+
+    assert latest_version_path.read_text().strip() == "1.0.1"
+
+
+@patch("tach.cache.access.get_project_path")
+@patch("tach.cache.access.request.urlopen")
+def test_update_latest_version_network_error(
+    mock_urlopen, mock_get_project_path, tmp_path
+):
+    project_path = tmp_path / "project"
+    latest_version_path = project_path / ".tach" / ".latest-version"
+    latest_version_path.parent.mkdir(parents=True, exist_ok=True)
+
+    mock_get_project_path.return_value = project_path
+    mock_urlopen.side_effect = URLError("Network error")
+
+    update_latest_version()
+    assert not latest_version_path.exists()


### PR DESCRIPTION
- Cache latest version in `.tach`
- Check current version against latest when cli is run and notify user to upgrade as needed
- Add `tach --version` and `tach.__version__`
- Make `cli`, `mod`, `clean`, and `sync` strict modules